### PR TITLE
uiautomator scrolling stabilization 

### DIFF
--- a/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
+++ b/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
@@ -8,7 +8,7 @@ public class UiScrollableCustom extends UiScrollable {
         super(container);
     }
 
-    private static final Long TIMEOUT = 1000L;
+    private static final Long TIMEOUT = 10L;
 
     public boolean scrollIntoView(UiSelector selector) throws UiObjectNotFoundException {
         return scrollIntoView(selector, false);
@@ -22,6 +22,7 @@ public class UiScrollableCustom extends UiScrollable {
     public boolean scrollIntoView(UiSelector selector, boolean forceScroll) throws UiObjectNotFoundException {
         Tracer.trace(new Object[]{selector});
         UiSelector childSelector = this.getSelector().childSelector(selector);
+        UiObject element = new UiObject(getDevice(), childSelector);
         boolean found = false;
 
         for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
@@ -29,27 +30,7 @@ public class UiScrollableCustom extends UiScrollable {
                 found = true;
             } else {
                 boolean scrolled = this.scrollForward(100);
-                getDevice().waitForIdle();
-                if (!forceScroll && !scrolled) break;
-            }
-        }
-        return found;
-    }
-
-    public boolean scrollIntoView(UiSelector selector, String targetBySelectorStrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        Tracer.trace(new Object[]{selector});
-        UiSelector childSelector = this.getSelector().childSelector(selector);
-        Method strategyMethod = By.class.getMethod(targetBySelectorStrategy, String.class);
-        BySelector byselector = (BySelector) strategyMethod.invoke(By.class, (String.valueOf(childSelector)));
-        boolean found = false;
-
-        for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
-            if (this.exists(childSelector)) {
-                found = true;
-            } else {
-                boolean scrolled = this.scrollForward(50);
-                getDevice().waitForIdle();
-                getDevice().wait(Until.findObject(byselector), TIMEOUT);
+                element.waitForExists(TIMEOUT);
                 if (!forceScroll && !scrolled) break;
             }
         }

--- a/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
+++ b/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
@@ -7,27 +7,52 @@ public class UiScrollableCustom extends UiScrollable {
     public UiScrollableCustom(UiSelector container) {
         super(container);
     }
-    Long TIMEOUT = 1000L;
+
+    private static final Long TIMEOUT = 1000L;
+
+    public boolean scrollIntoView(UiSelector selector) throws UiObjectNotFoundException {
+        return scrollIntoView(selector, false);
+    }
 
     /**
      * Method required because scrollForward return type is not reliable. It might return false, meaning that there is no
      * more space to scroll while it is not true. This method allows you to force to scroll even if scrollForward returns
      * false. When forcing to scroll, the method will stop scrolling when mMaxSearchSwipes is reached.
      */
-    public boolean scrollIntoView(UiSelector selector, String bystrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public boolean scrollIntoView(UiSelector selector, boolean forceScroll) throws UiObjectNotFoundException {
         Tracer.trace(new Object[]{selector});
         UiSelector childSelector = this.getSelector().childSelector(selector);
+        boolean found = false;
+
+        for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
+            if (this.exists(childSelector)) {
+                found = true;
+            } else {
+                boolean scrolled = this.scrollForward(100);
+                getDevice().waitForIdle();
+                if (!forceScroll && !scrolled) break;
+            }
+        }
+        return found;
+    }
+
+    public boolean scrollIntoView(UiSelector selector, String targetBySelectorStrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InvocationTargetException {
+        Tracer.trace(new Object[]{selector});
+        UiSelector childSelector = this.getSelector().childSelector(selector);
+        Method strategyMethod = By.class.getMethod(targetBySelectorStrategy, String.class);
+        BySelector byselector = (BySelector) strategyMethod.invoke(By.class, (String.valueOf(childSelector)));
         boolean found = false;
         if (this.exists(childSelector)) {
             found = true;
         }else {
-            for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
+            for (int x = 0; x < getMaxSearchSwipes(); ++x) {
                 boolean scrolled = this.scrollForward(50);
                 getDevice().waitForIdle();
-                Method strategyMethod = By.class.getMethod(bystrategy, String.class);
-                getDevice().wait(Until.findObject((BySelector) strategyMethod.invoke(By.class, (String.valueOf(childSelector)))), TIMEOUT);
-                found = true; if (this.exists(childSelector));
-                if (!forceScroll && !scrolled && found) break;
+                getDevice().wait(Until.findObject(byselector), TIMEOUT);
+                if (this.exists(childSelector)) {
+                    found = true; break;
+                };
+                if (!forceScroll && !scrolled) break;
             }
         }
         return found;

--- a/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
+++ b/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
@@ -1,8 +1,5 @@
 package androidx.test.uiautomator;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 public class UiScrollableCustom extends UiScrollable {
     public UiScrollableCustom(UiSelector container) {
         super(container);

--- a/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
+++ b/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
@@ -36,22 +36,20 @@ public class UiScrollableCustom extends UiScrollable {
         return found;
     }
 
-    public boolean scrollIntoView(UiSelector selector, String targetBySelectorStrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InvocationTargetException {
+    public boolean scrollIntoView(UiSelector selector, String targetBySelectorStrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Tracer.trace(new Object[]{selector});
         UiSelector childSelector = this.getSelector().childSelector(selector);
         Method strategyMethod = By.class.getMethod(targetBySelectorStrategy, String.class);
         BySelector byselector = (BySelector) strategyMethod.invoke(By.class, (String.valueOf(childSelector)));
         boolean found = false;
-        if (this.exists(childSelector)) {
-            found = true;
-        }else {
-            for (int x = 0; x < getMaxSearchSwipes(); ++x) {
+
+        for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
+            if (this.exists(childSelector)) {
+                found = true;
+            } else {
                 boolean scrolled = this.scrollForward(50);
                 getDevice().waitForIdle();
                 getDevice().wait(Until.findObject(byselector), TIMEOUT);
-                if (this.exists(childSelector)) {
-                    found = true; break;
-                };
                 if (!forceScroll && !scrolled) break;
             }
         }

--- a/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
+++ b/server/app/src/androidTest/java/androidx/test/uiautomator/UiScrollableCustom.java
@@ -1,30 +1,33 @@
 package androidx.test.uiautomator;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class UiScrollableCustom extends UiScrollable {
     public UiScrollableCustom(UiSelector container) {
         super(container);
     }
-
-    public boolean scrollIntoView(UiSelector selector) throws UiObjectNotFoundException {
-        return scrollIntoView(selector, false);
-    }
+    Long TIMEOUT = 1000L;
 
     /**
      * Method required because scrollForward return type is not reliable. It might return false, meaning that there is no
      * more space to scroll while it is not true. This method allows you to force to scroll even if scrollForward returns
      * false. When forcing to scroll, the method will stop scrolling when mMaxSearchSwipes is reached.
      */
-    public boolean scrollIntoView(UiSelector selector, boolean forceScroll) throws UiObjectNotFoundException {
+    public boolean scrollIntoView(UiSelector selector, String bystrategy, boolean forceScroll) throws UiObjectNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         Tracer.trace(new Object[]{selector});
         UiSelector childSelector = this.getSelector().childSelector(selector);
         boolean found = false;
-
-        for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
-            if (this.exists(childSelector)) {
-                found = true;
-            } else {
-                boolean scrolled = this.scrollForward(100);
-                if (!forceScroll && !scrolled) break;
+        if (this.exists(childSelector)) {
+            found = true;
+        }else {
+            for (int x = 0; x < getMaxSearchSwipes() && !found; ++x) {
+                boolean scrolled = this.scrollForward(50);
+                getDevice().waitForIdle();
+                Method strategyMethod = By.class.getMethod(bystrategy, String.class);
+                getDevice().wait(Until.findObject((BySelector) strategyMethod.invoke(By.class, (String.valueOf(childSelector)))), TIMEOUT);
+                found = true; if (this.exists(childSelector));
+                if (!forceScroll && !scrolled && found) break;
             }
         }
         return found;

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
@@ -31,7 +31,7 @@ public class ScrollToElementActionHelper {
             scrollable.setAsVerticalList();
         }
 
-        if (!scrollable.scrollIntoView(targetViewSelector, targetBySelectorStrategy,true)) {
+        if (!scrollable.scrollIntoView(targetViewSelector, targetBySelectorStrategy, true)) {
             String errorMessage = String.format("Found no elements for locator: %s by strategy: %s",
                   targetLocator, targetBySelectorStrategy);
             throw new UiObjectNotFoundException(errorMessage);

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
@@ -31,7 +31,7 @@ public class ScrollToElementActionHelper {
             scrollable.setAsVerticalList();
         }
 
-        if (!scrollable.scrollIntoView(targetViewSelector, targetBySelectorStrategy, true)) {
+        if (!scrollable.scrollIntoView(targetViewSelector, true)) {
             String errorMessage = String.format("Found no elements for locator: %s by strategy: %s",
                   targetLocator, targetBySelectorStrategy);
             throw new UiObjectNotFoundException(errorMessage);

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/ScrollToElementActionHelper.java
@@ -31,7 +31,7 @@ public class ScrollToElementActionHelper {
             scrollable.setAsVerticalList();
         }
 
-        if (!scrollable.scrollIntoView(targetViewSelector, true)) {
+        if (!scrollable.scrollIntoView(targetViewSelector, targetBySelectorStrategy,true)) {
             String errorMessage = String.format("Found no elements for locator: %s by strategy: %s",
                   targetLocator, targetBySelectorStrategy);
             throw new UiObjectNotFoundException(errorMessage);


### PR DESCRIPTION
Scrolling in Ui Automator is not stable, the scrolling will continue even if the condition to validate the element is met.
There is not enough delay between scrolling and checking for the element that exists on the screen, so scrolling and checking for the element occur simultaneously.

The delay that is added to wait for the element to exist provides sufficient time to validate the element's conditions. In the case of animation, adding a wait for idle will allow the screen to load.
