### PR TITLE
seekbar support for uiautomator

### DIFF
--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
@@ -1,15 +1,13 @@
 package sh.calaba.instrumentationbackend.actions.device;
 import static sh.calaba.instrumentationbackend.actions.device.StrategyUtils.verifyStrategy;
 
-import android.graphics.Rect;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.Direction;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Objects;
 import sh.calaba.instrumentationbackend.InstrumentationBackend;
 import sh.calaba.instrumentationbackend.Result;
 import sh.calaba.instrumentationbackend.actions.Action;
@@ -18,7 +16,7 @@ public class UiautomatorSeekBar implements Action{
     @Override
     public Result execute(String... args) {
         UiDevice device = InstrumentationBackend.getUiDevice();
-        String error_message =  "null";
+        int speed = 10;
 
         try {
             String strategy = args[0];
@@ -30,40 +28,24 @@ public class UiautomatorSeekBar implements Action{
             BySelector selector = (BySelector) strategyMethod.invoke(By.class, locator);
             UiObject2 seekBar = device.findObject(selector);
 
-            String from_direction = args[2];
-            String to_direction = args[3];
-            Rect bounds = seekBar.getVisibleBounds();
+            float percentage = Float.parseFloat(args[2]);
+            Direction direction = Direction.valueOf(args[3]);
 
-            int startX = bounds.left + bounds.width() / 4;
-            int endX = bounds.left + bounds.width() * 3 / 4;
-            int centerY = bounds.centerY();
-
-            if (Objects.equals(from_direction, "left") && Objects.equals(to_direction, "right")){
-                device.swipe(endX, centerY, startX, centerY, 10);
-            }
-            else if (Objects.equals(from_direction, "right") && Objects.equals(to_direction, "left")){
-                device.swipe(startX, centerY, endX, centerY, 10);
-            } else {
-                error_message= "Incorrect options check the arguments";
+            if (args.length >= 5) {
+                speed = Integer.parseInt(args[4]);
             }
 
-        } catch (NumberFormatException e) {
+            seekBar.swipe(direction, percentage, speed);
+
+        } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
 
-        if(String.valueOf(error_message) != "null") {
-            return new Result(true, error_message);
-        } else
-        {
-            return new Result(true);
-        }
-
+        return new Result(true);
     }
 
     @Override

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
@@ -18,6 +18,7 @@ public class UiautomatorSeekBar implements Action{
     @Override
     public Result execute(String... args) {
         UiDevice device = InstrumentationBackend.getUiDevice();
+        String error_message =  "null";
 
         try {
             String strategy = args[0];
@@ -42,6 +43,8 @@ public class UiautomatorSeekBar implements Action{
             }
             else if (Objects.equals(from_direction, "right") && Objects.equals(to_direction, "left")){
                 device.swipe(startX, centerY, endX, centerY, 10);
+            } else {
+                error_message= "Incorrect options check the arguments";
             }
 
         } catch (NumberFormatException e) {
@@ -54,7 +57,13 @@ public class UiautomatorSeekBar implements Action{
             throw new RuntimeException(e);
         }
 
-        return new Result(true);
+        if(String.valueOf(error_message) != "null") {
+            return new Result(true, error_message);
+        } else
+        {
+            return new Result(true);
+        }
+
     }
 
     @Override

--- a/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
+++ b/server/app/src/androidTest/java/sh/calaba/instrumentationbackend/actions/device/UiautomatorSeekBar.java
@@ -1,0 +1,64 @@
+package sh.calaba.instrumentationbackend.actions.device;
+import static sh.calaba.instrumentationbackend.actions.device.StrategyUtils.verifyStrategy;
+
+import android.graphics.Rect;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.BySelector;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import sh.calaba.instrumentationbackend.InstrumentationBackend;
+import sh.calaba.instrumentationbackend.Result;
+import sh.calaba.instrumentationbackend.actions.Action;
+
+public class UiautomatorSeekBar implements Action{
+    @Override
+    public Result execute(String... args) {
+        UiDevice device = InstrumentationBackend.getUiDevice();
+
+        try {
+            String strategy = args[0];
+            String locator = args[1];
+
+            verifyStrategy(strategy);
+
+            Method strategyMethod = By.class.getMethod(strategy, String.class);
+            BySelector selector = (BySelector) strategyMethod.invoke(By.class, locator);
+            UiObject2 seekBar = device.findObject(selector);
+
+            String from_direction = args[2];
+            String to_direction = args[3];
+            Rect bounds = seekBar.getVisibleBounds();
+
+            int startX = bounds.left + bounds.width() / 4;
+            int endX = bounds.left + bounds.width() * 3 / 4;
+            int centerY = bounds.centerY();
+
+            if (Objects.equals(from_direction, "left") && Objects.equals(to_direction, "right")){
+                device.swipe(endX, centerY, startX, centerY, 10);
+            }
+            else if (Objects.equals(from_direction, "right") && Objects.equals(to_direction, "left")){
+                device.swipe(startX, centerY, endX, centerY, 10);
+            }
+
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new Result(true);
+    }
+
+    @Override
+    public String key() {
+        return "uiautomator_seek_bar";
+    }
+}


### PR DESCRIPTION
Adding support for android Seekbar in compose screen, It can be flicked and scrolled by using following uiautomator method

`perform_action('uiautomator_seek_bar', 'strategy', 'selector', 'percentage', 'direction', 'speed')`

strategy: can be example: class, res, desc..
selector: is value from the strategy example : "android.widget.SeekBar"
direction: RIGHT, LEFT
percentage: value is between 0.0F and 1.0F
speed: speed at which the seek bar can be swiped, by default it is set to 10 and it is optional field.

For example:

If the seek bar needs to be scrolled from left to right
`perform_action('uiautomator_seek_bar', 'strategy', 'selector', 'percentage', 'RIGHT', '50')`

If the seek bar needs to be scrolling from right to left
`perform_action('uiautomator_seek_bar', 'strategy', 'selector', 'percentage', 'LEFT', '50')`


